### PR TITLE
refactor: 동시접속을 고려한 업로드 리벡토리 명칭 업데이트 로직 추가

### DIFF
--- a/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
@@ -53,7 +53,25 @@ public class PhotoService {
      */
     public GroupPhotosResponseDto uploadPhotos(List<MultipartFile> images) throws IOException {
         List<String> photos = new ArrayList<>();
+        File uploadDir = new File(uploadDirectory);
         int groupId = 1;
+
+        // 업로드 디렉토리 존재 여부 확인 및 생성
+        if (uploadDir.exists()) {
+            File[] groupDirs = uploadDir.listFiles(File::isDirectory);
+            if (groupDirs != null) {
+                for (File groupDir : groupDirs) {
+                    String dirName = groupDir.getName();
+                    if (dirName.startsWith("group")) {
+                        try {
+                            int existingGroupId = Integer.parseInt(dirName.substring(5));
+                            groupId = Math.max(groupId, existingGroupId + 1);
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                }
+            }
+        }
 
         // 공통 date와 timeStamp 생성
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");


### PR DESCRIPTION
## 🔎 관련 이슈
closed #29 

## 🔎 작업 내용
사진 업로드 기능 향상:
* [`src/main/java/stackup/stack_snapshot_back/service/PhotoService.java`](diffhunk://#diff-82727eb643812f8312da6f9209d7780190e034a20661cfff37b94fdbb4d543beR56-R75): 업로드 디렉토리가 존재하는지 확인하고 필요 시 생성하는 로직 추가. 또한, 기존 디렉토리를 기반으로 새로운 그룹 ID를 동적으로 생성하여 각 업로드 세션에 고유한 그룹 ID 보장.
