### PR TITLE
enhancement: 이미지 처리 로직 최적화

### DIFF
--- a/src/main/java/stackup/stack_snapshot_back/dto/SelectFrameRequestDto.java
+++ b/src/main/java/stackup/stack_snapshot_back/dto/SelectFrameRequestDto.java
@@ -2,7 +2,6 @@ package stackup.stack_snapshot_back.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -11,5 +10,5 @@ import java.util.List;
 public class SelectFrameRequestDto {
     private final Integer selectedFrameId;
     private final Integer groupId;
-    private final List<MultipartFile> file;
+    private final List<String> selectPhotoNames;
 }

--- a/src/main/java/stackup/stack_snapshot_back/restController/PhotoRestController.java
+++ b/src/main/java/stackup/stack_snapshot_back/restController/PhotoRestController.java
@@ -3,6 +3,7 @@ package stackup.stack_snapshot_back.restController;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.io.Resource;
@@ -22,6 +23,7 @@ import java.util.List;
  * 사진 처리 API 공통 컨트롤러
  * @since 2024.11.03
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/photos")
@@ -49,11 +51,17 @@ public class PhotoRestController {
      * @return GroupPhotosResponseDto groupId, date, timeStamp, (List)fileNames
      */
     @PostMapping
-    public ResponseEntity<GroupPhotosResponseDto> uploadPhotos(List<MultipartFile> images) {
+    public ResponseEntity<GroupPhotosResponseDto> uploadPhotos(@RequestParam("images") List<MultipartFile> images) {
+        if (images.isEmpty()) {
+            log.error("업로드할 사진이 없습니다.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+
         try {
             GroupPhotosResponseDto responseDto = photoService.uploadPhotos(images);
             return new ResponseEntity<>(responseDto, HttpStatus.OK);
         } catch (IOException e) {
+            log.error("사진 업로드 중 오류 발생: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }
     }
@@ -109,11 +117,11 @@ public class PhotoRestController {
 
     /**
      * 프레임 선택 및 사진 업로드 API
-     * @param SelectFrameRequestDto 업로드 요청 데이터 (selectedFrameId, groupId, file)
+     * @param SelectFrameRequestDto 업로드 요청 데이터 (selectedFrameId, groupId, List<String> selectPhotoNames)
      * @return PhotoResponseDto date, timeStamp, fileName
      */
     @PostMapping("/frames")
-    public ResponseEntity<PhotoResponseDto> uploadWithFrame(@ModelAttribute SelectFrameRequestDto requestDto) {
+    public ResponseEntity<PhotoResponseDto> uploadWithFrame(@RequestBody SelectFrameRequestDto requestDto) {
         try {
             PhotoResponseDto response = photoService.uploadFile(requestDto, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH);
             return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
@@ -2,6 +2,7 @@ package stackup.stack_snapshot_back.service;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
@@ -30,6 +31,7 @@ import java.util.Objects;
  * 사진 처리 서비스
  * @ latest update 2025.04.08
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PhotoService {
@@ -174,14 +176,14 @@ public class PhotoService {
 
     /**
      * 선택된 프레임 기반 사진 합성
-     * @param requestDto 업로드 요청 데이터 (selectedFrameId, groupId, file)
+     * @param requestDto 업로드 요청 데이터 (selectedFrameId, groupId, List<String> selectPhotos)
      * @param UPLOAD_PATH 업로드 경로
      * @param FRAME_PATH 프레임 경로
      * @param OUTPUT_PATH 출력 경로
      * @return PhotoResponseDto date, timeStamp, fileName
      */
     public PhotoResponseDto uploadFile(SelectFrameRequestDto requestDto, String UPLOAD_PATH, String FRAME_PATH, String OUTPUT_PATH) throws IOException {
-        List<MultipartFile> files = requestDto.getFile();
+        List<String> selectPhotoNames = requestDto.getSelectPhotoNames();
         int groupId = requestDto.getGroupId();
         int frameId = requestDto.getSelectedFrameId();
 
@@ -190,28 +192,17 @@ public class PhotoService {
         String timeStamp = date.split("_")[1];
         date = date.split("_")[0];
 
-        // 업로드된 파일 처리
-        List<String> fileNames = selectFrameService.FileUpload(UPLOAD_PATH, groupId, files);
+        // 이미지 병합
+        String combinedImagePath = selectFrameService.mergeImages(
+                selectPhotoNames, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH
+        );
 
-        // 이미지 합성
-        String combinedImagePath = selectFrameService.mergeImages(fileNames, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH);
-
-        PhotoResponseDto response = PhotoResponseDto.builder()
+        return PhotoResponseDto.builder()
                 .groupId(groupId)
                 .date(date)
                 .timeStamp(timeStamp)
                 .fileName(combinedImagePath)
                 .build();
-
-        // 임시 파일 삭제
-        for (String fileName : fileNames) {
-            File file = new File(UPLOAD_PATH + fileName);
-            if (file.exists()) {
-                file.delete();
-            }
-        }
-
-        return response;
     }
 
     /**

--- a/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
@@ -165,99 +165,82 @@ public class SelectFrameService {
                               String UPLOAD_PATH,
                               String FRAME_PATH,
                               String OUTPUT_PATH) throws IOException {
-        if(FRAME_PATH ==null) throw new IllegalArgumentException("FRAME_PATH가 null입니다.");
-        if(frameId>4||frameId<1) throw new IllegalArgumentException("FramdId의 범위는 1~4입니다.");
+        if(FRAME_PATH == null) throw new IllegalArgumentException("FRAME_PATH가 null입니다.");
+        if(frameId < 1 || frameId > 4) throw new IllegalArgumentException("FramdId의 범위는 1~4입니다.");
 
-        //FrameId에 해당하는 프레임에 필요한 이미지의 수를 구함
-        int ImageCount = OFFSET[frameId-1].length;
-
-        if (imageFiles.size() != ImageCount) {
-            throw new IllegalArgumentException("이미지 파일의 개수가 프레임에 맞지 않습니다. : "+imageFiles.size()+"/"+ImageCount);
+        // 프레임에 따라 이미지 개수 결정
+        int imageCount = OFFSET[frameId - 1].length;
+        if (imageFiles.size() != imageCount) {
+            throw new IllegalArgumentException("이미지 파일의 개수가 프레임에 맞지 않습니다. : " + imageFiles.size() + "/" + imageCount);
         }
 
         try {
-            BufferedImage baseImage = null;
-
             // 프레임 이미지 로드
-            if(frameId!=4){
-                baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"."+EXT));
-            } else{
-                // FrameId가 4일 현재 날짜(일)에 따라 불러옴
-                if(new Date().getDate()!=1){
-                    baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"-1."+EXT));
-                }
-                else{
-                    baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"-2."+EXT));
-                }
-            }
+            BufferedImage baseImage = loadFrameImage(FRAME_PATH, frameId);
 
             Graphics2D frame = baseImage.createGraphics();
 
-            // 프레임에 들어갈 사진 저장하는 변수
-            BufferedImage Image;
-
-            // 프레임에 들어갈 이미지의 수 만큼 반복
-            for(int i=0;i<ImageCount;i++){
-                System.out.println(i);
-                Image = ImageIO.read(new File(UPLOAD_PATH+imageFiles.get(i)));
-                frame.drawImage(Image,OFFSET[frameId-1][i][0],OFFSET[frameId-1][i][1],null);
+            // 프레임에 들어갈 이미지 그리기
+            for (int i = 0; i < imageCount; i++) {
+                BufferedImage image = ImageIO.read(new File(UPLOAD_PATH + "group" + groupId + "/" + imageFiles.get(i)));
+                frame.drawImage(image, OFFSET[frameId - 1][i][0], OFFSET[frameId - 1][i][1], null);
             }
 
-            BufferedImage second_baseImage;
+            // 두 번째 프레임 이미지 덮어쓰기
+            BufferedImage secondBaseImage = loadFrameImage(FRAME_PATH, frameId);
+            frame.drawImage(secondBaseImage, 0, 0, null);
 
-            // 프레임 이미지 로드
-            if(frameId!=4){
-                second_baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"."+EXT));
-            }
-            else{
-                if(new Date().getDate()!=1){
-                    second_baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"-1."+EXT));
-                }
-                else{
-                    second_baseImage = ImageIO.read(new File(FRAME_PATH +frameId+"-2."+EXT));
-                }
+            // 텍스트 추가 (frameId가 4가 아닌 경우)
+            if (frameId != 4) {
+                String currentDate = generateCurrentDate();
+                addTextToFrame(frame, currentDate, frameId);
             }
 
-            frame.drawImage(second_baseImage,0,0,null);
-            if(frameId!=4){
-                String current = generateCurrentDate();
-                // Font.PLAIN 부분 {Font. PLAIN,Font. BOLD,Font. ITALIC} 중 선택 가능
-                Font font = new Font(FONTNAME, Font.PLAIN,FONT_SIZE_AT_FRAME[frameId-1]);
-                Rectangle r = getFontrect(current, font);
-
-                int width = (int) r.getWidth();
-                int height = (int) r.getHeight();
-
-                BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-                Graphics2D g2d = getG2D(img);
-                g2d.setFont(font);
-                FontMetrics fm = g2d.getFontMetrics();
-                g2d.setColor(TEXT_COLOR[frameId-1]);
-                g2d.drawString(current, 0, fm.getAscent());
-
-
-                frame.drawImage(img,TEXT_OFFSET[frameId-1][0],TEXT_OFFSET[frameId-1][1],null);
-                g2d.dispose();
-            }
-
-            //프레임 위에 사진 이미지 작성 종료 후 닫기
             frame.dispose();
 
-            //파일명 생성을 위한 FileNameGenerator 객체 생성
-            FileNameGenerator filenamegenerator = new FileNameGenerator();
-
-            // 완성된 사진 파일명 예: group_1_final_20241014_215154.png
+            // 파일명 생성
             String fileName = "group_" + groupId + "_final_" + date + "_" + timeStamp + ".png";
 
-            //최종 파일 생성 및 이미지 쓰기
-            File outputFile = new File(OUTPUT_PATH+fileName);
-
+            // 최종 파일 생성 및 저장
+            File outputFile = new File(OUTPUT_PATH + fileName);
             ImageIO.write(baseImage, EXT, outputFile);
 
             return fileName;
         } catch (Exception e) {
             throw new IOException("이미지 파일 읽기중 문제가 생겼습니다.:"+e);
         }
+    }
+
+    /** 프레임 이미지 로드
+     * @param FRAME_PATH 프레임 경로
+     * @param frameId 프레임 ID
+     * @return BufferedImage 프레임 이미지
+     */
+    private BufferedImage loadFrameImage(String FRAME_PATH, int frameId) throws IOException {
+        if (frameId != 4) {
+            return ImageIO.read(new File(FRAME_PATH + frameId + "." + EXT));
+        }
+        String suffix = (new Date().getDate() != 1) ? "-1" : "-2";
+        return ImageIO.read(new File(FRAME_PATH + frameId + suffix + "." + EXT));
+    }
+
+    /** 프레임에 텍스트 추가
+     * @param frame 프레임 이미지
+     * @param text 추가할 텍스트
+     * @param frameId 프레임 ID
+     */
+    private void addTextToFrame(Graphics2D frame, String text, int frameId) {
+        Font font = new Font(FONTNAME, Font.PLAIN, FONT_SIZE_AT_FRAME[frameId - 1]);
+        Rectangle textRect = getFontrect(text, font);
+
+        BufferedImage textImage = new BufferedImage(textRect.width, textRect.height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = getG2D(textImage);
+        g2d.setFont(font);
+        g2d.setColor(TEXT_COLOR[frameId - 1]);
+        g2d.drawString(text, 0, g2d.getFontMetrics().getAscent());
+        g2d.dispose();
+
+        frame.drawImage(textImage, TEXT_OFFSET[frameId - 1][0], TEXT_OFFSET[frameId - 1][1], null);
     }
 
     /**

--- a/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
@@ -243,23 +243,23 @@ public class SelectFrameService {
      * @param frameId 프레임 ID
      */
     private void addTextToFrame(Graphics2D frame, String text, int frameId) {
-        int frameIdex = frameId - 1;
+        int frameIndex = frameId - 1;
 
-        Font font = new Font(FONTNAME, Font.PLAIN, FONT_SIZE_AT_FRAME[frameIdex]);
+        Font font = new Font(FONTNAME, Font.PLAIN, FONT_SIZE_AT_FRAME[frameIndex]);
 
 //        Rectangle textRect = getFontrect(text, font);
 //        BufferedImage textImage = new BufferedImage(textRect.width, textRect.height, BufferedImage.TYPE_INT_ARGB);
 //        Graphics2D g2d = getG2D(textImage);
 //        g2d.setFont(font);
-//        g2d.setColor(TEXT_COLOR[frameIdex]);
+//        g2d.setColor(TEXT_COLOR[frameIndex]);
 //        g2d.drawString(text, 0, g2d.getFontMetrics().getAscent());
 //        g2d.dispose();
-//        frame.drawImage(textImage, TEXT_OFFSET[frameIdex][0], TEXT_OFFSET[frameIdex][1], null);
+//        frame.drawImage(textImage, TEXT_OFFSET[frameIndex][0], TEXT_OFFSET[frameIndex][1], null);
 
         Rectangle textRect = getFontrect(text, font);
         frame.setFont(font);
-        frame.setColor(TEXT_COLOR[frameIdex]);
-        frame.drawString(text, TEXT_OFFSET[frameIdex][0], TEXT_OFFSET[frameIdex][1] + textRect.height);
+        frame.setColor(TEXT_COLOR[frameIndex]);
+        frame.drawString(text, TEXT_OFFSET[frameIndex][0], TEXT_OFFSET[frameIndex][1] + textRect.height);
     }
 
     /**

--- a/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
@@ -169,7 +169,7 @@ public class SelectFrameService {
                               String FRAME_PATH,
                               String OUTPUT_PATH) throws IOException {
         if(FRAME_PATH == null) throw new IllegalArgumentException("FRAME_PATH가 null입니다.");
-        if(frameId < 1 || frameId > 4) throw new IllegalArgumentException("FramdId의 범위는 1~4입니다.");
+        if(frameId < 1 || frameId > 4) throw new IllegalArgumentException("FrameId의 범위는 1~4입니다.");
 
         // 프레임에 따라 이미지 개수 결정
         int imageCount = OFFSET[frameId - 1].length;

--- a/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.web.multipart.MultipartFile;
 import stackup.stack_snapshot_back.util.FileNameGenerator;
@@ -28,8 +29,10 @@ import stackup.stack_snapshot_back.util.FileNameGenerator;
  */
 @Service
 public class SelectFrameService {
+    // 프레임 이미지 캐시
+    private final ConcurrentHashMap<Integer, BufferedImage> frameImageCache = new ConcurrentHashMap<>();
+
     final String FONTNAME = "Pretendard";
-    // 저장될 이미지 포멧
     final String EXT = "png";
 
     final int[] FONT_SIZE_AT_FRAME = {
@@ -175,9 +178,11 @@ public class SelectFrameService {
         }
 
         try {
-            // 프레임 이미지 로드
+            // 프레임 이미지 로드 (loadFrameImage - 캐싱된 이미지 사용)
             BufferedImage baseImage = loadFrameImage(FRAME_PATH, frameId);
+            BufferedImage secondBaseImage = frameId != 4 ? baseImage : loadFrameImage(FRAME_PATH, frameId);
 
+            // Graphics2D 객체 생성
             Graphics2D frame = baseImage.createGraphics();
 
             // 프레임에 들어갈 이미지 그리기
@@ -187,7 +192,6 @@ public class SelectFrameService {
             }
 
             // 두 번째 프레임 이미지 덮어쓰기
-            BufferedImage secondBaseImage = loadFrameImage(FRAME_PATH, frameId);
             frame.drawImage(secondBaseImage, 0, 0, null);
 
             // 텍스트 추가 (frameId가 4가 아닌 경우)
@@ -217,11 +221,20 @@ public class SelectFrameService {
      * @return BufferedImage 프레임 이미지
      */
     private BufferedImage loadFrameImage(String FRAME_PATH, int frameId) throws IOException {
+        // 캐싱된 이미지가 있으면 반환
+        if (frameImageCache.containsKey(frameId)) return frameImageCache.get(frameId);
+
+        // 캐싱된 이미지가 없으면 로드
+        BufferedImage frameImage;
         if (frameId != 4) {
-            return ImageIO.read(new File(FRAME_PATH + frameId + "." + EXT));
+            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + "." + EXT));
+        } else {
+            String suffix = (new Date().getDate() != 1) ? "-1" : "-2";
+            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + suffix + "." + EXT));
         }
-        String suffix = (new Date().getDate() != 1) ? "-1" : "-2";
-        return ImageIO.read(new File(FRAME_PATH + frameId + suffix + "." + EXT));
+
+        frameImageCache.put(frameId, frameImage); // 캐싱
+        return frameImage;
     }
 
     /** 프레임에 텍스트 추가
@@ -230,17 +243,23 @@ public class SelectFrameService {
      * @param frameId 프레임 ID
      */
     private void addTextToFrame(Graphics2D frame, String text, int frameId) {
-        Font font = new Font(FONTNAME, Font.PLAIN, FONT_SIZE_AT_FRAME[frameId - 1]);
+        int frameIdex = frameId - 1;
+
+        Font font = new Font(FONTNAME, Font.PLAIN, FONT_SIZE_AT_FRAME[frameIdex]);
+
+//        Rectangle textRect = getFontrect(text, font);
+//        BufferedImage textImage = new BufferedImage(textRect.width, textRect.height, BufferedImage.TYPE_INT_ARGB);
+//        Graphics2D g2d = getG2D(textImage);
+//        g2d.setFont(font);
+//        g2d.setColor(TEXT_COLOR[frameIdex]);
+//        g2d.drawString(text, 0, g2d.getFontMetrics().getAscent());
+//        g2d.dispose();
+//        frame.drawImage(textImage, TEXT_OFFSET[frameIdex][0], TEXT_OFFSET[frameIdex][1], null);
+
         Rectangle textRect = getFontrect(text, font);
-
-        BufferedImage textImage = new BufferedImage(textRect.width, textRect.height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = getG2D(textImage);
-        g2d.setFont(font);
-        g2d.setColor(TEXT_COLOR[frameId - 1]);
-        g2d.drawString(text, 0, g2d.getFontMetrics().getAscent());
-        g2d.dispose();
-
-        frame.drawImage(textImage, TEXT_OFFSET[frameId - 1][0], TEXT_OFFSET[frameId - 1][1], null);
+        frame.setFont(font);
+        frame.setColor(TEXT_COLOR[frameIdex]);
+        frame.drawString(text, TEXT_OFFSET[frameIdex][0], TEXT_OFFSET[frameIdex][1] + textRect.height);
     }
 
     /**


### PR DESCRIPTION
## 🔎 관련 이슈
closed #33 

## 🔎 작업 내용

### DTO 및 API 변경 사항:
* `src/main/java/stackup/stack_snapshot_back/dto/SelectFrameRequestDto.java`
	* request에서 파일을 받아오는 자료형 `List<MultipartFile>`을 `List<String>`으로 대체
	* 사용되지 않는 `MultipartFile`의 import를 제거

### 로깅 강화:
* `src/main/java/stackup/stack_snapshot_back/restController/PhotoRestController.java`
	* 로깅을 위한 `@Slf4j` 어노테이션 추가
	* 빈 이미지 업로드 및 사진 업로드 중 예외에 대한 오류 로깅 포함
* `src/main/java/stackup/stack_snapshot_back/service/PhotoService.java`
	* 로깅을 위한 `@Slf4j` 어노테이션 추가

### 이미지 병합 최적화:
* `src/main/java/stackup/stack_snapshot_back/service/PhotoService.java`
	* `uploadFile` 메서드를 `List<MultipartFile>` 대신 `List<String> selectPhotoNames`를 사용하도록 업데이트
	* 이미지 병합 프로세스 단순화, 임시 파일 삭제 제거
* `src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java`
	* 프레임 이미지 로딩을 최적화하기 위해 `ConcurrentHashMap`을 사용한 프레임 이미지 캐시 도입
	* 캐시된 이미지를 활용하도록 `mergeImages` 메서드 리팩토링
	* 프레임 이미지를 로드하고 프레임에 텍스트를 추가하는 보조 메서드 추가

## 적용 결과
- 최적화 전
<img width="1028" alt="100 복사본" src="https://github.com/user-attachments/assets/4ea3d84f-2b8e-403e-a343-b90ffde93070" />

- 최적화 후
<img width="1457" alt="이미지최전화후100" src="https://github.com/user-attachments/assets/03dc0a51-bd7e-4dec-b2db-b5928bd4d59d" />

