### PR TITLE
enhancement: 이미지 병합 로직 비동기 처리

### DIFF
--- a/src/main/java/stackup/stack_snapshot_back/config/WebConfig.java
+++ b/src/main/java/stackup/stack_snapshot_back/config/WebConfig.java
@@ -3,10 +3,12 @@ package stackup.stack_snapshot_back.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@EnableAsync
 @Configuration
 public class WebConfig {
 

--- a/src/main/java/stackup/stack_snapshot_back/restController/PhotoRestController.java
+++ b/src/main/java/stackup/stack_snapshot_back/restController/PhotoRestController.java
@@ -18,6 +18,7 @@ import stackup.stack_snapshot_back.service.PhotoService;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * 사진 처리 API 공통 컨트롤러
@@ -121,15 +122,10 @@ public class PhotoRestController {
      * @return PhotoResponseDto date, timeStamp, fileName
      */
     @PostMapping("/frames")
-    public ResponseEntity<PhotoResponseDto> uploadWithFrame(@RequestBody SelectFrameRequestDto requestDto) {
-        try {
-            PhotoResponseDto response = photoService.uploadFile(requestDto, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-        } catch (IOException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
-        }
+    public CompletableFuture<ResponseEntity<PhotoResponseDto>> uploadWithFrame(@RequestBody SelectFrameRequestDto requestDto) throws IOException {
+        return photoService.uploadFile(requestDto, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH)
+                .thenApply(response -> new ResponseEntity<>(response, HttpStatus.OK))
+                .exceptionally(ex -> new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     /**

--- a/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/PhotoService.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * 사진 처리 서비스
@@ -54,11 +55,8 @@ public class PhotoService {
      * @return GroupPhotosResponseDto groupId, date, timeStamp, (List)fileNames
      */
     public GroupPhotosResponseDto uploadPhotos(List<MultipartFile> images) throws IOException {
-        List<String> photos = new ArrayList<>();
-        File uploadDir = new File(uploadDirectory);
         int groupId = 1;
-
-        // 업로드 디렉토리 존재 여부 확인 및 생성
+        File uploadDir = new File(uploadDirectory);
         if (uploadDir.exists()) {
             File[] groupDirs = uploadDir.listFiles(File::isDirectory);
             if (groupDirs != null) {
@@ -75,26 +73,51 @@ public class PhotoService {
             }
         }
 
-        // 공통 date와 timeStamp 생성
+        // 날짜 및 시간 생성
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
-        String date = sdf.format(new Date());
-        String timeStamp = date.split("_")[1];
-        date = date.split("_")[0];
+        String dateTime = sdf.format(new Date());
+        String[] parts = dateTime.split("_");
+        String date = parts[0];
+        String timeStamp = parts[1];
 
-        for (int i = 0; i < images.size(); i++) {
-            MultipartFile image = images.get(i);
-            File groupDirectory = new File(uploadDirectory, "group" + groupId);
+        // 각 파일 업로드를 병렬 처리
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        int index = 0;
+        for (MultipartFile image : images) {
+            final int fileIndex = index;
+            int finalGroupId = groupId;
+            CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    File groupDirectory = new File(uploadDirectory, "group" + finalGroupId);
 
-            if (!groupDirectory.exists() && !groupDirectory.mkdirs()) {
-                throw new IOException("Failed to create group directory: " + groupDirectory.getAbsolutePath());
-            }
+                    // synchronized - 경쟁 조건 방지
+                    synchronized (PhotoService.class) {
+                        if (!groupDirectory.exists() && !groupDirectory.mkdirs()) {
+                            throw new IOException("Failed to create group directory: " + groupDirectory.getAbsolutePath());
+                        }
+                    }
 
-            GeneratedFileInfo fileInfo = fileNameGenerator.generateOriginalFileName(groupId, i + 1, Objects.requireNonNull(image.getOriginalFilename()), date, timeStamp);
-            Path filePath = Paths.get(groupDirectory.getAbsolutePath(), fileInfo.getFileName());
-            image.transferTo(filePath.toFile());
-
-            photos.add(fileInfo.getFileName());
+                    GeneratedFileInfo fileInfo = fileNameGenerator.generateOriginalFileName(
+                            finalGroupId, fileIndex + 1, Objects.requireNonNull(image.getOriginalFilename()), date, timeStamp);
+                    Path filePath = Paths.get(groupDirectory.getAbsolutePath(), fileInfo.getFileName());
+                    image.transferTo(filePath.toFile());
+                    return fileInfo.getFileName();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            futures.add(future);
+            index++;
         }
+        // 모든 업로드 작업 완료 후 파일명을 수집
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(
+                futures.toArray(new CompletableFuture[0])
+        );
+        List<String> photos = allFutures.thenApply(v -> {
+            List<String> fileNames = new ArrayList<>();
+            futures.forEach(f -> fileNames.add(f.join()));
+            return fileNames;
+        }).join();
 
         return GroupPhotosResponseDto.builder()
                 .groupId(groupId)
@@ -175,35 +198,66 @@ public class PhotoService {
     }
 
     /**
-     * 선택된 프레임 기반 사진 합성
+     * 선택된 프레임 기반 사진 합성 - 비동기
      * @param requestDto 업로드 요청 데이터 (selectedFrameId, groupId, List<String> selectPhotos)
      * @param UPLOAD_PATH 업로드 경로
      * @param FRAME_PATH 프레임 경로
      * @param OUTPUT_PATH 출력 경로
      * @return PhotoResponseDto date, timeStamp, fileName
      */
-    public PhotoResponseDto uploadFile(SelectFrameRequestDto requestDto, String UPLOAD_PATH, String FRAME_PATH, String OUTPUT_PATH) throws IOException {
+    public CompletableFuture<PhotoResponseDto> uploadFile(SelectFrameRequestDto requestDto, String UPLOAD_PATH, String FRAME_PATH, String OUTPUT_PATH) throws IOException {
         List<String> selectPhotoNames = requestDto.getSelectPhotoNames();
         int groupId = requestDto.getGroupId();
         int frameId = requestDto.getSelectedFrameId();
 
+        // 공통 date 및 timeStamp 생성
         SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
-        String date = sdf.format(new Date());
-        String timeStamp = date.split("_")[1];
-        date = date.split("_")[0];
+        String curDate = sdf.format(new Date());
+        String[] parts = curDate.split("_");
+        String date = parts[0];
+        String timeStamp = parts[1];
 
-        // 이미지 병합
-        String combinedImagePath = selectFrameService.mergeImages(
-                selectPhotoNames, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH
-        );
-
-        return PhotoResponseDto.builder()
-                .groupId(groupId)
-                .date(date)
-                .timeStamp(timeStamp)
-                .fileName(combinedImagePath)
-                .build();
+        // 비동기적으로 이미지 병합 작업 실행
+        return selectFrameService.mergeImagesAsync(selectPhotoNames, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH)
+                .thenApply(combinedImagePath -> PhotoResponseDto.builder()
+                        .groupId(groupId)
+                        .date(date)
+                        .timeStamp(timeStamp)
+                        .fileName(combinedImagePath)
+                        .build());
     }
+
+
+    /**
+     * 선택된 프레임 기반 사진 합성 - 동기
+     * @param requestDto 업로드 요청 데이터 (selectedFrameId, groupId, List<String> selectPhotos)
+     * @param UPLOAD_PATH 업로드 경로
+     * @param FRAME_PATH 프레임 경로
+     * @param OUTPUT_PATH 출력 경로
+     * @return PhotoResponseDto date, timeStamp, fileName
+     */
+//    public PhotoResponseDto uploadFile(SelectFrameRequestDto requestDto, String UPLOAD_PATH, String FRAME_PATH, String OUTPUT_PATH) throws IOException {
+//        List<String> selectPhotoNames = requestDto.getSelectPhotoNames();
+//        int groupId = requestDto.getGroupId();
+//        int frameId = requestDto.getSelectedFrameId();
+//
+//        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+//        String date = sdf.format(new Date());
+//        String timeStamp = date.split("_")[1];
+//        date = date.split("_")[0];
+//
+//        // 이미지 병합
+//        String combinedImagePath = selectFrameService.mergeImages(
+//                selectPhotoNames, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH
+//        );
+//
+//        return PhotoResponseDto.builder()
+//                .groupId(groupId)
+//                .date(date)
+//                .timeStamp(timeStamp)
+//                .fileName(combinedImagePath)
+//                .build();
+//    }
 
     /**
      * 최종 합성 이미지 반환

--- a/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
+++ b/src/main/java/stackup/stack_snapshot_back/service/SelectFrameService.java
@@ -3,6 +3,7 @@ package stackup.stack_snapshot_back.service;
 import lombok.extern.java.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
@@ -17,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -31,9 +33,28 @@ import stackup.stack_snapshot_back.util.FileNameGenerator;
 public class SelectFrameService {
     // 프레임 이미지 캐시
     private final ConcurrentHashMap<Integer, BufferedImage> frameImageCache = new ConcurrentHashMap<>();
+    private final BufferedImage[] frameCache = new BufferedImage[5];  // 인덱스 1~4 사용
 
     final String FONTNAME = "Pretendard";
     final String EXT = "png";
+
+    /** 프레임 이미지 로드
+     * @param FRAME_PATH 프레임 경로
+     * @param frameId 프레임 ID
+     * @return BufferedImage 프레임 이미지
+     */
+    private BufferedImage loadFrameImage(String FRAME_PATH, int frameId) throws IOException {
+        if (frameImageCache.containsKey(frameId)) return frameImageCache.get(frameId);
+        BufferedImage frameImage;
+        if (frameId != 4) {
+            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + "." + EXT));
+        } else {
+            String suffix = (new java.util.Date().getDate() != 1) ? "-1" : "-2";
+            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + suffix + "." + EXT));
+        }
+        frameImageCache.put(frameId, frameImage);
+        return frameImage;
+    }
 
     final int[] FONT_SIZE_AT_FRAME = {
             12,
@@ -215,26 +236,23 @@ public class SelectFrameService {
         }
     }
 
-    /** 프레임 이미지 로드
-     * @param FRAME_PATH 프레임 경로
-     * @param frameId 프레임 ID
-     * @return BufferedImage 프레임 이미지
-     */
-    private BufferedImage loadFrameImage(String FRAME_PATH, int frameId) throws IOException {
-        // 캐싱된 이미지가 있으면 반환
-        if (frameImageCache.containsKey(frameId)) return frameImageCache.get(frameId);
-
-        // 캐싱된 이미지가 없으면 로드
-        BufferedImage frameImage;
-        if (frameId != 4) {
-            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + "." + EXT));
-        } else {
-            String suffix = (new Date().getDate() != 1) ? "-1" : "-2";
-            frameImage = ImageIO.read(new File(FRAME_PATH + frameId + suffix + "." + EXT));
+    @Async
+    public CompletableFuture<String> mergeImagesAsync(List<String> imageFiles,
+                                                      int groupId,
+                                                      int frameId,
+                                                      String date,
+                                                      String timeStamp,
+                                                      String UPLOAD_PATH,
+                                                      String FRAME_PATH,
+                                                      String OUTPUT_PATH) {
+        try {
+            String result = mergeImages(imageFiles, groupId, frameId, date, timeStamp, UPLOAD_PATH, FRAME_PATH, OUTPUT_PATH);
+            return CompletableFuture.completedFuture(result);
+        } catch (IOException e) {
+            CompletableFuture<String> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
         }
-
-        frameImageCache.put(frameId, frameImage); // 캐싱
-        return frameImage;
     }
 
     /** 프레임에 텍스트 추가


### PR DESCRIPTION
## 🔎 관련 이슈
closed #32 


## 🔎 작업 내용
사진 업로드 기능, 프레임 병합 기능 비동기 처리 도입

- 비동기 처리 활성화
- 메서드가 `CompletableFuture`를 반환하도록 수정
- 비동기 작업을 위한 헬퍼 메서드 추가

## 🔎 작업 세부 내용
- config
   - `config/WebConfig.java`: `@EnableAsync` - 비동기 처리 활성화

- controller

   - `restController/PhotoRestController.java`: `uploadWithFrame` 비동기 처리를 위해 `CompletableFuture<ResponseEntity<PhotoResponseDto>>`를 반환하도록 변경

- service

   - `service/PhotoService.java`: 파일 업로드 비동기 처리
   - `service/PhotoService.java`: 프레임 병합 비동기 처리 - `uploadFile` 메서드가 `CompletableFuture<PhotoResponseDto>`를 반환하도록 수정
   - `service/SelectFrameService.java`: 프레임 병합 비동기 처리 - `mergeImagesAsync` 메서드 도입


## 🔎 개선 전 후
(개선 전)
<img width="1028" alt="최적화 전 100" src="https://github.com/user-attachments/assets/91db2ac9-8608-415a-bb31-ecfa66c79f49" />

(개선 후)
<img width="1183" alt="비동기적용후 100" src="https://github.com/user-attachments/assets/9901b9b9-f8e2-47ce-ace9-6923d1914c54" />

